### PR TITLE
Fix: Change shebang in docker-entrypoint.sh to /bin/sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 echo "Starting SpeakInsights..."
 
 # Start the backend API


### PR DESCRIPTION
I've changed the shebang from `#!/bin/bash` to `#!/bin/sh` in `docker-entrypoint.sh`. This resolves a potential 'no such file or directory' error when running the container if `/bin/bash` is not available in the base image (e.g., `python:3.9-slim`). The script's contents are POSIX-compliant and do not require bash-specific features.

I also verified that your Dockerfile correctly copies and sets execute permissions for the entrypoint script.