### PR TITLE
Feat: Use PORT environment variable for backend service

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,8 +2,9 @@
 echo "Starting SpeakInsights..."
 
 # Start the backend API
-echo "Starting backend on port 8000..."
-uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+BACKEND_PORT=${PORT:-8000}
+echo "Starting backend on port ${BACKEND_PORT}..."
+uvicorn app.main:app --host 0.0.0.0 --port ${BACKEND_PORT} &
 
 # Health check for backend
 echo "Waiting for backend to be healthy..."
@@ -12,7 +13,7 @@ MAX_RETRIES=30 # Try for 30 seconds (30 * 1 second sleep)
 HEALTHY=false
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
     # Try to curl the /docs endpoint, suppress output, and fail on error
-    if curl -s --fail http://localhost:8000/docs > /dev/null; then
+    if curl -s --fail http://localhost:${BACKEND_PORT}/docs > /dev/null; then
         echo "Backend is healthy!"
         HEALTHY=true
         break


### PR DESCRIPTION
I modified `docker-entrypoint.sh` to allow the Uvicorn backend server to listen on the port specified by the `PORT` environment variable.

- If `PORT` is set, Uvicorn will use its value.
- If `PORT` is not set, Uvicorn will default to port `8000`.
- The health check mechanism was also updated to target the configured port.

This change enhances compatibility with cloud platforms like Cloud Run that dynamically assign ports via the `PORT` environment variable.